### PR TITLE
Fix absolute path in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "java.configuration.updateBuildConfiguration": "automatic",
-    "cmake.sourceDirectory": "/home/akoun/Documents/PROJETS/ELYSEE/bee_app/linux"
+    "cmake.sourceDirectory": "${workspaceFolder}/linux"
 }


### PR DESCRIPTION
## Summary
- use a workspace-relative CMake path in `.vscode/settings.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68412ced3af8832db140149278709120