### PR TITLE
refactor: reuse shared audit model

### DIFF
--- a/lib/screens/admin/audit_logs_screen.dart
+++ b/lib/screens/admin/audit_logs_screen.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../../models/audit_log_model.dart';
 import '../../services/audit_service.dart';
 import '../../utils/theme.dart';
-import '../../widgets/common_widgets.dart';
 import '../../widgets/admin_app_bar.dart';
 import '../../widgets/admin_drawer.dart';
+import '../../widgets/common_widgets.dart';
 
 // Écran des logs d'audit pour les administrateurs
 class AuditLogsScreen extends StatefulWidget {

--- a/lib/services/audit_service.dart
+++ b/lib/services/audit_service.dart
@@ -1,5 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+import '../models/audit_log_model.dart';
+
 // Service pour l'audit et les logs des actions administratives
 class AuditService {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
@@ -185,66 +187,3 @@ class AuditService {
   }
 }
 
-// Modèle pour les logs d'audit
-class AuditLogModel {
-  final String id;
-  final String adminId;
-  final String adminEmail;
-  final String action;
-  final String targetType;
-  final String targetId;
-  final Map<String, dynamic>? oldData;
-  final Map<String, dynamic>? newData;
-  final String? description;
-  final DateTime timestamp;
-  final String? ipAddress;
-  final String? userAgent;
-
-  AuditLogModel({
-    required this.id,
-    required this.adminId,
-    required this.adminEmail,
-    required this.action,
-    required this.targetType,
-    required this.targetId,
-    this.oldData,
-    this.newData,
-    this.description,
-    required this.timestamp,
-    this.ipAddress,
-    this.userAgent,
-  });
-
-  Map<String, dynamic> toMap() {
-    return {
-      'adminId': adminId,
-      'adminEmail': adminEmail,
-      'action': action,
-      'targetType': targetType,
-      'targetId': targetId,
-      'oldData': oldData,
-      'newData': newData,
-      'description': description,
-      'timestamp': timestamp,
-      'ipAddress': ipAddress,
-      'userAgent': userAgent,
-    };
-  }
-
-  factory AuditLogModel.fromMap(Map<String, dynamic> map, String id) {
-    return AuditLogModel(
-      id: id,
-      adminId: map['adminId'] ?? '',
-      adminEmail: map['adminEmail'] ?? '',
-      action: map['action'] ?? '',
-      targetType: map['targetType'] ?? '',
-      targetId: map['targetId'] ?? '',
-      oldData: map['oldData'],
-      newData: map['newData'],
-      description: map['description'],
-      timestamp: (map['timestamp'] as Timestamp).toDate(),
-      ipAddress: map['ipAddress'],
-      userAgent: map['userAgent'],
-    );
-  }
-}


### PR DESCRIPTION
## Summary
- use shared `AuditLogModel` across services and screens
- remove duplicate `AuditLogModel` class from audit service

## Testing
- `dart analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c063b8cb10832d813907d6e90c101b