### PR TITLE
Handle non-Timestamp createdAt in AgentModel

### DIFF
--- a/lib/models/agent_model.dart
+++ b/lib/models/agent_model.dart
@@ -63,7 +63,9 @@ class AgentModel {
       averageRating: (map['averageRating'] ?? 0.0).toDouble(),
       ratingCount: map['ratingCount'] ?? 0,
       isAvailable: map['isAvailable'] ?? true,
-      createdAt: (map['createdAt'] as Timestamp).toDate(),
+      createdAt: (map['createdAt'] is Timestamp)
+          ? (map['createdAt'] as Timestamp).toDate()
+          : DateTime.now(),
       email: map['email'],
       phoneNumber: map['phoneNumber'],
       specialty: map['specialty'],


### PR DESCRIPTION
## Summary
- Safely parse `createdAt` in `AgentModel.fromMap` by verifying that the value is a Firestore `Timestamp`

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart compile exe lib/main.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c063b9c15c832dbf1db9eece2a5632