### PR TITLE
Replace prints with structured logging

### DIFF
--- a/lib/services/advanced_notification_service.dart
+++ b/lib/services/advanced_notification_service.dart
@@ -36,7 +36,7 @@ class AdvancedNotificationService extends ChangeNotifier {
       notifyListeners();
     } catch (e) {
       if (kDebugMode) {
-        print('Erreur lors de l\'initialisation des notifications: $e');
+        debugPrint('Erreur lors de l\'initialisation des notifications: $e');
       }
     }
   }
@@ -75,7 +75,7 @@ class AdvancedNotificationService extends ChangeNotifier {
       // Obtenir le token FCM
       _fcmToken = await _messaging.getToken();
       if (kDebugMode) {
-        print('Token FCM: $_fcmToken');
+        debugPrint('Token FCM: $_fcmToken');
       }
 
       // Écouter les changements de token
@@ -105,7 +105,7 @@ class AdvancedNotificationService extends ChangeNotifier {
   // Gérer les messages en foreground
   Future<void> _handleForegroundMessage(RemoteMessage message) async {
     if (kDebugMode) {
-      print('Message reçu en foreground: ${message.messageId}');
+      debugPrint('Message reçu en foreground: ${message.messageId}');
     }
 
     // Afficher une notification locale
@@ -122,7 +122,7 @@ class AdvancedNotificationService extends ChangeNotifier {
   // Gérer les messages en background
   Future<void> _handleBackgroundMessage(RemoteMessage message) async {
     if (kDebugMode) {
-      print('Message reçu en background: ${message.messageId}');
+      debugPrint('Message reçu en background: ${message.messageId}');
     }
 
     // Traiter l'action selon le type de notification
@@ -253,7 +253,7 @@ class AdvancedNotificationService extends ChangeNotifier {
 
     } catch (e) {
       if (kDebugMode) {
-        print('Erreur lors de l\'envoi de la notification admin: $e');
+        debugPrint('Erreur lors de l\'envoi de la notification admin: $e');
       }
       rethrow;
     }
@@ -275,7 +275,7 @@ class AdvancedNotificationService extends ChangeNotifier {
         await _sendMulticastMessage(batch, title, body, data);
       } catch (e) {
         if (kDebugMode) {
-          print('Erreur lors de l\'envoi du batch $i: $e');
+          debugPrint('Erreur lors de l\'envoi du batch $i: $e');
         }
       }
     }
@@ -320,7 +320,7 @@ class AdvancedNotificationService extends ChangeNotifier {
       }
     } catch (e) {
       if (kDebugMode) {
-        print('Erreur lors de l\'envoi FCM: $e');
+        debugPrint('Erreur lors de l\'envoi FCM: $e');
       }
       rethrow;
     }
@@ -368,7 +368,7 @@ class AdvancedNotificationService extends ChangeNotifier {
 
     } catch (e) {
       if (kDebugMode) {
-        print('Erreur lors de l\'envoi de la notification personnalisée: $e');
+        debugPrint('Erreur lors de l\'envoi de la notification personnalisée: $e');
       }
       rethrow;
     }
@@ -386,7 +386,7 @@ class AdvancedNotificationService extends ChangeNotifier {
       });
     } catch (e) {
       if (kDebugMode) {
-        print('Erreur lors de la sauvegarde de la notification: $e');
+        debugPrint('Erreur lors de la sauvegarde de la notification: $e');
       }
     }
   }
@@ -416,7 +416,7 @@ class AdvancedNotificationService extends ChangeNotifier {
           .toList();
     } catch (e) {
       if (kDebugMode) {
-        print('Erreur lors de la récupération des notifications: $e');
+        debugPrint('Erreur lors de la récupération des notifications: $e');
       }
       return [];
     }

--- a/lib/services/audit_service.dart
+++ b/lib/services/audit_service.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:logger/logger.dart';
 
 // Service pour l'audit et les logs des actions administratives
+final logger = Logger();
 class AuditService {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   late final CollectionReference _auditCollection;
@@ -39,7 +41,7 @@ class AuditService {
       await _auditCollection.add(auditLog.toMap());
     } catch (e) {
       // En cas d'erreur, on ne veut pas bloquer l'action principale
-      print('Erreur lors de l\'enregistrement du log d\'audit: $e');
+      logger.w('Erreur lors de l\'enregistrement du log d\'audit: $e');
     }
   }
 

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -1,9 +1,13 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:logger/logger.dart';
 import '../models/agent_model.dart';
 import '../models/reservation_model.dart';
 import '../models/review_model.dart';
 import '../models/user_model.dart';
 import 'agent_availability_service.dart';
+
+final logger = Logger();
 
 // Service pour gérer les opérations de base de données Firestore avec gestion améliorée des erreurs et timeouts
 class DatabaseService {
@@ -742,7 +746,7 @@ class DatabaseService {
       } catch (agentUpdateError) {
         // Si la mise à jour de l'agent échoue, on continue quand même
         // L'avis a été créé avec succès, c'est le plus important
-        print(
+        logger.w(
           'Avertissement: Impossible de mettre à jour la note de l\'agent: $agentUpdateError',
         );
       }
@@ -756,7 +760,7 @@ class DatabaseService {
         await updateReservation(updatedReservation);
       } catch (reservationUpdateError) {
         // Si la mise à jour de la réservation échoue, on continue quand même
-        print(
+        logger.w(
           'Avertissement: Impossible de mettre à jour la réservation: $reservationUpdateError',
         );
       }


### PR DESCRIPTION
## Summary
- Use `debugPrint` instead of `print` for notification service debugging
- Introduce `Logger` in audit and database services to warn on non-critical failures
- Remove remaining `print` calls for consistent logging

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c063bafe0c832d8fe59564e34161d2